### PR TITLE
Create version_builder.cc

### DIFF
--- a/librocksdb_sys/version_builder.cc
+++ b/librocksdb_sys/version_builder.cc
@@ -1,0 +1,89 @@
+#include "utilities/titandb/version_builder.h"
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
+#include <inttypes.h>
+
+namespace rocksdb {
+namespace titandb {
+
+void VersionBuilder::Builder::AddFile(
+    const std::shared_ptr<BlobFileMeta>& file) {
+  auto number = file->file_number();
+  auto sb = base_.lock();
+  if (sb->files_.find(number) != sb->files_.end() ||
+      added_files_.find(number) != added_files_.end()) {
+    fprintf(stderr, "blob file %" PRIu64 " has been added before\n", number);
+    abort();
+  }
+  if (deleted_files_.find(number) != deleted_files_.end()) {
+    fprintf(stderr, "blob file %" PRIu64 " has been deleted before\n", number);
+    abort();
+  }
+  added_files_.emplace(number, file);
+}
+
+void VersionBuilder::Builder::DeleteFile(uint64_t number) {
+  auto sb = base_.lock();
+  if (sb->files_.find(number) == sb->files_.end() &&
+      added_files_.find(number) == added_files_.end()) {
+    fprintf(stderr, "blob file %" PRIu64 " doesn't exist before\n", number);
+    abort();
+  }
+  if (deleted_files_.find(number) != deleted_files_.end()) {
+    fprintf(stderr, "blob file %" PRIu64 " has been deleted before\n", number);
+    abort();
+  }
+  deleted_files_.emplace(number);
+}
+
+std::shared_ptr<BlobStorage> VersionBuilder::Builder::Build() {
+  // If nothing is changed, we can reuse the base;
+  if (added_files_.empty() && deleted_files_.empty()) {
+    return base_.lock();
+  }
+
+  auto vs = std::make_shared<BlobStorage>(*base_.lock());
+  vs->AddBlobFiles(added_files_);
+  vs->DeleteBlobFiles(deleted_files_);
+  vs->ComputeGCScore();
+  return vs;
+}
+
+VersionBuilder::VersionBuilder(Version* base) : base_(base) {
+  base_->Ref();
+  for (auto& it : base_->column_families_) {
+    column_families_.emplace(it.first, Builder(it.second));
+  }
+}
+
+VersionBuilder::~VersionBuilder() { base_->Unref(); }
+
+void VersionBuilder::Apply(VersionEdit* edit) {
+  auto cf_id = edit->column_family_id_;
+  auto it = column_families_.find(cf_id);
+  if (it == column_families_.end()) {
+    // Ignore unknown column families.
+    return;
+  }
+  auto& builder = it->second;
+
+  for (auto& file : edit->deleted_files_) {
+    builder.DeleteFile(file);
+  }
+  for (auto& file : edit->added_files_) {
+    builder.AddFile(file);
+  }
+}
+
+void VersionBuilder::SaveTo(Version* v) {
+  v->column_families_.clear();
+  for (auto& it : column_families_) {
+    v->column_families_.emplace(it.first, it.second.Build());
+  }
+}
+
+}  // namespace titandb
+}  // namespace rocksdb


### PR DESCRIPTION
when i build tikv project,i hit an error like below:
OS:centos 
version: 3.10.0-123.el7.x86_64
cmake version:3.11.2
gcc version:5.3.0
###################
/root/.cargo/git/checkouts/rust-rocksdb-82ef6e5337b3fbe6/263b82e/librocksdb_sys/rocksdb/utilities/titandb/version_builder.cc: In member function ‘void rocksdb::titandb::VersionBuilder::Builder::AddFile(const std::shared_ptr<rocksdb::titandb::BlobFileMeta>&)’:
/root/.cargo/git/checkouts/rust-rocksdb-82ef6e5337b3fbe6/263b82e/librocksdb_sys/rocksdb/utilities/titandb/version_builder.cc:14:35: error: expected ‘)’ before ‘PRIu64’
     fprintf(stderr, "blob file %" PRIu64 " has been added before\n", number);
####################
I modify the source code,and workaround the issue.
rust-rocksdb/librocksdb_sys/rocksdb/utilities/titandb/version_builder.cc